### PR TITLE
Fix jsPDF fallback script tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,11 @@
     }
   </style>
   <script src="/stresscheck/jspdf.umd.min.js"></script>
-  <script>if (!window.jspdf) document.write('<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.0/jspdf.umd.min.js"></script>
+  <script>
+    if (!window.jspdf) {
+      document.write('<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.0/jspdf.umd.min.js"><\\/script>');
+    }
+  </script>
 </head>
 <body>
   <header>


### PR DESCRIPTION
## Summary
- ensure jsPDF fallback script closes properly

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/stresscheck/package.json')*