### PR TITLE
Fix malformed script tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,11 @@
     }
   </style>
   <script src="/stresscheck/jspdf.umd.min.js"></script>
-  <script>if (!window.jspdf) document.write('<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.0/jspdf.umd.min.js"></script>
+  <script>
+    if (!window.jspdf) {
+      document.write('<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.0/jspdf.umd.min.js"><\\/script>');
+    }
+  </script>
 </head>
 <body>
   <header>


### PR DESCRIPTION
## Summary
- fix an unclosed script tag in `index.html`
- ensure proper fallback loading for jspdf

## Testing
- `node -e` snippet to parse first script
- `node` script to parse all inline scripts