### PR TITLE
Fix jsPDF fallback load to avoid blank page

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,9 @@
   <script src="/stresscheck/jspdf.umd.min.js"></script>
   <script>
     if (!window.jspdf) {
-      document.write('<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.0/jspdf.umd.min.js"><\\/script>');
+      const s = document.createElement('script');
+      s.src = 'https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.0/jspdf.umd.min.js';
+      document.head.appendChild(s);
     }
   </script>
 </head>


### PR DESCRIPTION
## Summary
- ensure the fallback jsPDF script is loaded without using `document.write`

## Testing
- `true`