### PR TITLE
Add browser crypto support

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -1,16 +1,39 @@
-const crypto = require('crypto');
+let nodeCrypto;
+if (typeof window === 'undefined') {
+  nodeCrypto = require('crypto');
+}
 
 async function generateAnonymousID(company, username, password) {
   const input = `${company}_${username}_${password}`;
-  // Hashing for compatibility with browser version, though not used in ID
-  crypto.createHash('sha256').update(input).digest('hex');
+  await hashData(input); // compute hash for parity with browser version
   const companyPrefix = (company.slice(0, 3) || 'UNK').toUpperCase();
   const randomNum = Math.floor(1000 + Math.random() * 9000);
   return `${companyPrefix}_${randomNum}`;
 }
 
 async function hashPassword(password) {
-  return crypto.createHash('sha256').update(password).digest('hex');
+  return hashData(password);
 }
 
-module.exports = { generateAnonymousID, hashPassword };
+async function hashData(data) {
+  if (typeof window !== 'undefined' && window.crypto && window.crypto.subtle) {
+    const encoder = new TextEncoder();
+    const msgBuffer = encoder.encode(data);
+    const hashBuffer = await window.crypto.subtle.digest('SHA-256', msgBuffer);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+  }
+  if (nodeCrypto) {
+    return nodeCrypto.createHash('sha256').update(data).digest('hex');
+  }
+  throw new Error('Crypto API unavailable');
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { generateAnonymousID, hashPassword };
+}
+
+if (typeof window !== 'undefined') {
+  window.generateAnonymousID = generateAnonymousID;
+  window.hashPassword = hashPassword;
+}


### PR DESCRIPTION
## Summary
- fallback to `window.crypto` when available
- export utility functions globally for browser usage

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c36231b84832cba4fd9b97d8b3142