### PR TITLE
Add redirect to Stripe checkout

### DIFF
--- a/index.html
+++ b/index.html
@@ -355,6 +355,8 @@
       let authMode = '';
       let adminCSVRows = [];
 
+      const STRIPE_URL = 'https://buy.stripe.com/test_9B67sE3KQ9Sqa2GeYE9oc00';
+
       // 質問描画関数
       function renderQuestions(section, questions, prefix, labels) {
         section.innerHTML = '';
@@ -508,6 +510,7 @@
           localStorage.removeItem('autosave');
           // PDFボタンを有効化
           document.getElementById('downloadPDF').disabled = false;
+          window.location.href = STRIPE_URL;
         } catch (e) {
           console.error('フォーム送信エラー:', e);
           alert('データの送信に失敗しました。もう一度お試しください。');
@@ -563,6 +566,7 @@
               adminPanel.classList.remove('hidden');
               currentCompany = company;
               loadAdminData(company);
+              window.location.href = STRIPE_URL;
             } else {
               const hashedInput = await hashPassword(password);
               if (hashedInput === savedPass) {
@@ -570,6 +574,7 @@
                 adminPanel.classList.remove('hidden');
                 currentCompany = company;
                 loadAdminData(company);
+                window.location.href = STRIPE_URL;
               } else {
                 alert("管理者パスワードが違います。");
                 return;


### PR DESCRIPTION
## Summary
- add constant for Stripe URL in client script
- redirect administrators to Stripe after successful login
- redirect users to Stripe after viewing stress check results

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ec5f936ec832cad426c1c4abd0999